### PR TITLE
Fix Boolean and Number types

### DIFF
--- a/src/components/layout/index.tsx
+++ b/src/components/layout/index.tsx
@@ -7,7 +7,7 @@ interface Props {
     children: ReactNode,
     parent: string,
     title: string,
-    margintop?: Boolean,
+    margintop?: boolean,
 }
 
 const Layout = ({

--- a/src/components/league/index.tsx
+++ b/src/components/league/index.tsx
@@ -11,7 +11,7 @@ const ChangeHelper = Dynamic(() => import('./boxes/ChangeHelper'), { loading: ()
 const TableView = Dynamic(() => import('./table'), { loading: () => <Spinner/> });
 
 export default function League() {
-  const [boxHeight, setBoxHeight] = useState<number>(Number);
+  const [boxHeight, setBoxHeight] = useState<number>(0);
 
   const { currencyValues, cardsTable } = useContext(Contexts.leaguePageData);
 

--- a/src/components/league/table/div-card/card-reward.tsx
+++ b/src/components/league/table/div-card/card-reward.tsx
@@ -3,7 +3,7 @@ import styles from './index.module.css';
 interface Props {
     RewardName: string,
     rewardClass: string,
-    isCorrupted: Boolean
+    isCorrupted: boolean
 }
 
 export default function CardReward({ RewardName, rewardClass, isCorrupted }: Props) {

--- a/src/components/league/table/index.tsx
+++ b/src/components/league/table/index.tsx
@@ -16,7 +16,7 @@ import TableWrapper from '../../table/wrapper';
 
 export default function Table() {
   const [toHover, setToHover] = useState<KeyStates>();
-  const [isSticky, setSticky] = useState<Boolean>(false);
+  const [isSticky, setSticky] = useState<boolean>(false);
 
   const { navbarHeight } = useContext(Contexts.leaguePageData);
 

--- a/src/components/league/table/tbody/tr.tsx
+++ b/src/components/league/table/tbody/tr.tsx
@@ -12,6 +12,8 @@ import Td from '@/components/table/td';
 import { memo } from 'react';
 import styles from '../index.module.css';
 
+const DIVINATION_CARD_CLASS = 6;
+
 const DivCard = Dynamic(() => import('../div-card'), { loading: () => <div className="mr-2"><Spinner /></div> });
 const formatNumber: Function = require('@/hooks/formatNumber');
 
@@ -136,7 +138,7 @@ function Tr({
                         {
                           itemName: Reward.name,
                           searchMaxValue: Reward.chaosprice,
-                          isCard: Number(Card.Details.rewardClass) === 6,
+                          isCard: Number(Card.Details.rewardClass) === DIVINATION_CARD_CLASS,
                           isCorrupted: Card.Details.isCorrupted || false,
                         }
                     }
@@ -157,7 +159,7 @@ function Tr({
                         {
                           itemName: Reward.name,
                           searchMaxValue: Reward.chaosprice,
-                          isCard: Number(Card.Details.rewardClass) === 6,
+                          isCard: Number(Card.Details.rewardClass) === DIVINATION_CARD_CLASS,
                           isCorrupted: Card.Details.isCorrupted || false,
                         }
                     }

--- a/src/components/league/table/tbody/tr.tsx
+++ b/src/components/league/table/tbody/tr.tsx
@@ -136,10 +136,7 @@ function Tr({
                         {
                           itemName: Reward.name,
                           searchMaxValue: Reward.chaosprice,
-                          // @ts-expect-error all good here actualy.
-                          // eslint-disable-next-line eqeqeq
-                          isCard: Card.Details.rewardClass == 6,
-                          // @ts-expect-error all good here actualy.
+                          isCard: Number(Card.Details.rewardClass) === 6,
                           isCorrupted: Card.Details.isCorrupted || false,
                         }
                     }
@@ -160,10 +157,7 @@ function Tr({
                         {
                           itemName: Reward.name,
                           searchMaxValue: Reward.chaosprice,
-                          // @ts-expect-error all good here actualy.
-                          // eslint-disable-next-line eqeqeq
-                          isCard: Card.Details.rewardClass == 6,
-                          // @ts-expect-error all good here actualy.
+                          isCard: Number(Card.Details.rewardClass) === 6,
                           isCorrupted: Card.Details.isCorrupted || false,
                         }
                     }

--- a/src/components/league/table/thead/index.tsx
+++ b/src/components/league/table/thead/index.tsx
@@ -6,7 +6,7 @@ import TableStyles from '../../../table/index.module.css';
 import Th from '../../../table/th';
 
 interface Props {
-    ShouldSticky: Boolean,
+    ShouldSticky: boolean,
     setToHover: Function,
     toHover: KeyStates,
 }

--- a/src/components/table/th/index.tsx
+++ b/src/components/table/th/index.tsx
@@ -12,7 +12,7 @@ interface Props {
     KeyState?: KeyStates,
     SortKey?: KeyStates,
     _Key: KeyStates,
-    enableClick?: Boolean,
+    enableClick?: boolean,
     SortType?: 0 | 1;
     Class?: string
 }

--- a/src/hooks/interfaces.ts
+++ b/src/hooks/interfaces.ts
@@ -4,7 +4,7 @@ export type CardDetail = {
     CardStack: number,
     RewardName: string,
     rewardClass: string,
-    isCorrupted: Boolean,
+    isCorrupted: boolean,
     Flavour: string
   };
 
@@ -29,7 +29,7 @@ export type TableData = {
     setexprice: number,
     chaosprofit: number,
     exprofit: number,
-    isCurrency: Boolean
+    isCurrency: boolean
   };
 
 export type LeagueDetails = {
@@ -42,7 +42,7 @@ export type LeagueDetails = {
   };
 
 export type LeagueResult = {
-    success: Boolean,
+    success: boolean,
     details: LeagueDetails
   };
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,7 +15,7 @@ import Loader from '@/components/loader';
 import Script from 'next/script';
 
 function MyApp({ Component, pageProps, router }: AppProps) {
-  const [isLoading, setLoading] = useState<Boolean>(false);
+  const [isLoading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
     const handleStart = (url: string) => (url !== router.asPath) && setLoading(true);

--- a/src/pages/_error.tsx
+++ b/src/pages/_error.tsx
@@ -3,8 +3,8 @@ import type { NextPageContext } from 'next';
 import styles from '@/components/error.module.css';
 
 interface Props {
-  statusCode: Number,
-  leagueError?: Boolean
+  statusCode: number,
+  leagueError?: boolean
 }
 
 function Error({ statusCode, leagueError = false }: Props) {

--- a/src/pages/league/[leagueName].tsx
+++ b/src/pages/league/[leagueName].tsx
@@ -43,8 +43,8 @@ interface Props {
 
 const League = ({ host }: Props) => {
   const [navbarHeight, setNavbarHeight] = useState<number>(40);
-  const [leagueExist, setLeagueExist] = useState<Boolean>(false);
-  const [receivedLeagueData, setReceivedLeagueData] = useState<Boolean>(false);
+  const [leagueExist, setLeagueExist] = useState<boolean>(false);
+  const [receivedLeagueData, setReceivedLeagueData] = useState<boolean>(false);
   const [leagueDetails, setLeagueDetails] = useState<LeagueDetailsType>();
   const [leagueTable, setLeagueTable] = useState <Array<TableData>>([]);
 


### PR DESCRIPTION
## Summary
- use primitive types for interfaces and `useState` generics
- remove unused `ts-expect-error`
- fix reward class comparison

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d952a93888333b569fabed25751d7