### PR TITLE
Fix resize event cleanup

### DIFF
--- a/src/components/league/boxes/ChangeHelper.tsx
+++ b/src/components/league/boxes/ChangeHelper.tsx
@@ -153,7 +153,7 @@ export default function ChangeHelper({
     window.addEventListener('resize', HandleElement);
     return () => {
       // eslint-disable-next-line no-undef
-      window.removeEventListener('resize', () => HandleElement);
+      window.removeEventListener('resize', HandleElement);
     };
   }, [BoxElement]);
 

--- a/src/components/league/navbar/index.tsx
+++ b/src/components/league/navbar/index.tsx
@@ -34,7 +34,7 @@ export default function Navbar({ UpdateHeigh }: Props) {
     window.addEventListener('resize', HandleElement);
     return () => {
       // eslint-disable-next-line no-undef
-      window.removeEventListener('resize', () => HandleElement);
+      window.removeEventListener('resize', HandleElement);
     };
   }, [element]);
 


### PR DESCRIPTION
## Summary
- clean up resize event listener correctly in Navbar and ChangeHelper

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d9532003483338ccd3711d0477073